### PR TITLE
Application SEGFAULT when upload is finished

### DIFF
--- a/src/xpiks-qt/Models/artworkuploader.cpp
+++ b/src/xpiks-qt/Models/artworkuploader.cpp
@@ -61,7 +61,7 @@ namespace Models {
         endProcessing();
         m_Percent = 100;
         updateProgress();
-        delete m_ActiveUploads;
+//        delete m_ActiveUploads;
     }
 
     void ArtworkUploader::credentialsTestingFinished()


### PR DESCRIPTION
I haven't found any memory allocation for this pointer: m_ActiveUploads .
After uploads are finished the application crashes with an error:
*** Error in `xpiks-qt': free(): invalid pointer: 0x00007f15c9036a78 ***