### PR TITLE
QT 5.2 QML modules compatibility

### DIFF
--- a/src/xpiks-qt/Components/AddIcon.qml
+++ b/src/xpiks-qt/Components/AddIcon.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import "../Constants"
 import "../Constants/Colors.js" as Colors
 

--- a/src/xpiks-qt/Components/CheckedComponent.qml
+++ b/src/xpiks-qt/Components/CheckedComponent.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import "../Constants"
 import "../Constants/Colors.js" as Colors
 

--- a/src/xpiks-qt/Components/CloseIcon.qml
+++ b/src/xpiks-qt/Components/CloseIcon.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import "../Constants"
 import "../Constants/Colors.js" as Colors
 

--- a/src/xpiks-qt/Components/CustomBorder.qml
+++ b/src/xpiks-qt/Components/CustomBorder.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import "../Constants"
 import "../Constants/Colors.js" as Colors
 

--- a/src/xpiks-qt/Components/EditableTags.qml
+++ b/src/xpiks-qt/Components/EditableTags.qml
@@ -20,7 +20,7 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Controls 1.2
+import QtQuick.Controls 1.1
 import QtQuick.Layouts 1.1
 import xpiks 1.0
 import "../Constants"

--- a/src/xpiks-qt/Components/EditableTags.qml
+++ b/src/xpiks-qt/Components/EditableTags.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Layouts 1.1
 import xpiks 1.0

--- a/src/xpiks-qt/Components/LargeAddIcon.qml
+++ b/src/xpiks-qt/Components/LargeAddIcon.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import "../Constants"
 import "../Constants/Colors.js" as Colors
 

--- a/src/xpiks-qt/Components/LargeRemoveIcon.qml
+++ b/src/xpiks-qt/Components/LargeRemoveIcon.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import "../Constants"
 import "../Constants/Colors.js" as Colors
 

--- a/src/xpiks-qt/Dialogs/AboutWindow.qml
+++ b/src/xpiks-qt/Dialogs/AboutWindow.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Controls 1.2
 import QtQuick.Layouts 1.1

--- a/src/xpiks-qt/Dialogs/AboutWindow.qml
+++ b/src/xpiks-qt/Dialogs/AboutWindow.qml
@@ -20,8 +20,8 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Dialogs 1.2
-import QtQuick.Controls 1.2
+import QtQuick.Dialogs 1.1
+import QtQuick.Controls 1.1
 import QtQuick.Layouts 1.1
 import "../Constants"
 import "../Constants/Colors.js" as Colors;

--- a/src/xpiks-qt/Dialogs/ArtworkPreview.qml
+++ b/src/xpiks-qt/Dialogs/ArtworkPreview.qml
@@ -19,11 +19,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
-import QtQuick.Controls 1.2
+import QtQuick 2.2
+import QtQuick.Controls 1.1
 import QtQuick.Layouts 1.1
-import QtQuick.Dialogs 1.2
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Dialogs 1.1
+import QtQuick.Controls.Styles 1.1
 import "../Constants"
 import "../Constants/Colors.js" as Colors;
 import "../Common.js" as Common;

--- a/src/xpiks-qt/Dialogs/CombinedArtworksDialog.qml
+++ b/src/xpiks-qt/Dialogs/CombinedArtworksDialog.qml
@@ -20,10 +20,10 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Controls 1.2
+import QtQuick.Controls 1.1
 import QtQuick.Layouts 1.1
-import QtQuick.Dialogs 1.2
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Dialogs 1.1
+import QtQuick.Controls.Styles 1.1
 import xpiks 1.0
 import "../Constants"
 import "../Constants/Colors.js" as Colors;

--- a/src/xpiks-qt/Dialogs/CombinedArtworksDialog.qml
+++ b/src/xpiks-qt/Dialogs/CombinedArtworksDialog.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Layouts 1.1
 import QtQuick.Dialogs 1.2

--- a/src/xpiks-qt/Dialogs/EnterMasterPasswordDialog.qml
+++ b/src/xpiks-qt/Dialogs/EnterMasterPasswordDialog.qml
@@ -18,7 +18,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Controls 1.2
 import QtQuick.Layouts 1.1

--- a/src/xpiks-qt/Dialogs/EnterMasterPasswordDialog.qml
+++ b/src/xpiks-qt/Dialogs/EnterMasterPasswordDialog.qml
@@ -19,8 +19,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import QtQuick 2.2
-import QtQuick.Dialogs 1.2
-import QtQuick.Controls 1.2
+import QtQuick.Dialogs 1.1
+import QtQuick.Controls 1.1
 import QtQuick.Layouts 1.1
 import "../Constants"
 import "../Constants/Colors.js" as Colors;

--- a/src/xpiks-qt/Dialogs/ExportMetadata.qml
+++ b/src/xpiks-qt/Dialogs/ExportMetadata.qml
@@ -20,10 +20,10 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Controls 1.2
+import QtQuick.Controls 1.1
 import QtQuick.Layouts 1.1
-import QtQuick.Dialogs 1.2
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Dialogs 1.1
+import QtQuick.Controls.Styles 1.1
 import "../Constants"
 import "../Constants/Colors.js" as Colors;
 import "../Common.js" as Common;

--- a/src/xpiks-qt/Dialogs/ExportMetadata.qml
+++ b/src/xpiks-qt/Dialogs/ExportMetadata.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Layouts 1.1
 import QtQuick.Dialogs 1.2

--- a/src/xpiks-qt/Dialogs/ImportMetadata.qml
+++ b/src/xpiks-qt/Dialogs/ImportMetadata.qml
@@ -20,10 +20,10 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Controls 1.2
+import QtQuick.Controls 1.1
 import QtQuick.Layouts 1.1
-import QtQuick.Dialogs 1.2
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Dialogs 1.1
+import QtQuick.Controls.Styles 1.1
 import "../Constants"
 import "../Constants/Colors.js" as Colors;
 import "../Common.js" as Common;

--- a/src/xpiks-qt/Dialogs/ImportMetadata.qml
+++ b/src/xpiks-qt/Dialogs/ImportMetadata.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Layouts 1.1
 import QtQuick.Dialogs 1.2

--- a/src/xpiks-qt/Dialogs/KeywordsSuggestion.qml
+++ b/src/xpiks-qt/Dialogs/KeywordsSuggestion.qml
@@ -20,10 +20,10 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Controls 1.2
+import QtQuick.Controls 1.1
 import QtQuick.Layouts 1.1
-import QtQuick.Dialogs 1.2
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Dialogs 1.1
+import QtQuick.Controls.Styles 1.1
 import "../Constants"
 import "../Constants/Colors.js" as Colors;
 import "../Common.js" as Common;

--- a/src/xpiks-qt/Dialogs/KeywordsSuggestion.qml
+++ b/src/xpiks-qt/Dialogs/KeywordsSuggestion.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Layouts 1.1
 import QtQuick.Dialogs 1.2

--- a/src/xpiks-qt/Dialogs/LogsDialog.qml
+++ b/src/xpiks-qt/Dialogs/LogsDialog.qml
@@ -20,10 +20,10 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Controls 1.2
+import QtQuick.Controls 1.1
 import QtQuick.Layouts 1.1
-import QtQuick.Dialogs 1.2
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Dialogs 1.1
+import QtQuick.Controls.Styles 1.1
 import "../Constants"
 import "../Constants/Colors.js" as Colors;
 import "../Common.js" as Common;

--- a/src/xpiks-qt/Dialogs/LogsDialog.qml
+++ b/src/xpiks-qt/Dialogs/LogsDialog.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Layouts 1.1
 import QtQuick.Dialogs 1.2

--- a/src/xpiks-qt/Dialogs/MasterPasswordSetupDialog.qml
+++ b/src/xpiks-qt/Dialogs/MasterPasswordSetupDialog.qml
@@ -18,7 +18,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Controls 1.2
 import QtQuick.Layouts 1.1

--- a/src/xpiks-qt/Dialogs/MasterPasswordSetupDialog.qml
+++ b/src/xpiks-qt/Dialogs/MasterPasswordSetupDialog.qml
@@ -19,8 +19,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import QtQuick 2.2
-import QtQuick.Dialogs 1.2
-import QtQuick.Controls 1.2
+import QtQuick.Dialogs 1.1
+import QtQuick.Controls 1.1
 import QtQuick.Layouts 1.1
 import "../Constants"
 import "../Constants/Colors.js" as Colors;

--- a/src/xpiks-qt/Dialogs/SettingsWindow.qml
+++ b/src/xpiks-qt/Dialogs/SettingsWindow.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Controls 1.2
 import QtQuick.Layouts 1.1

--- a/src/xpiks-qt/Dialogs/SettingsWindow.qml
+++ b/src/xpiks-qt/Dialogs/SettingsWindow.qml
@@ -20,8 +20,8 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Dialogs 1.2
-import QtQuick.Controls 1.2
+import QtQuick.Dialogs 1.1
+import QtQuick.Controls 1.1
 import QtQuick.Layouts 1.1
 import "../Constants"
 import "../Constants/Colors.js" as Colors;

--- a/src/xpiks-qt/Dialogs/UploadArtworks.qml
+++ b/src/xpiks-qt/Dialogs/UploadArtworks.qml
@@ -20,10 +20,10 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Controls 1.2
+import QtQuick.Controls 1.1
 import QtQuick.Layouts 1.1
-import QtQuick.Dialogs 1.2
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Dialogs 1.1
+import QtQuick.Controls.Styles 1.1
 import xpiks 1.0
 import "../Constants"
 import "../Constants/Colors.js" as Colors;

--- a/src/xpiks-qt/Dialogs/UploadArtworks.qml
+++ b/src/xpiks-qt/Dialogs/UploadArtworks.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Layouts 1.1
 import QtQuick.Dialogs 1.2

--- a/src/xpiks-qt/Dialogs/WarningsDialog.qml
+++ b/src/xpiks-qt/Dialogs/WarningsDialog.qml
@@ -20,9 +20,9 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Dialogs 1.2
-import QtQuick.Controls 1.2
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Dialogs 1.1
+import QtQuick.Controls 1.1
+import QtQuick.Controls.Styles 1.1
 import QtQuick.Layouts 1.1
 import "../Constants"
 import "../Constants/Colors.js" as Colors;

--- a/src/xpiks-qt/Dialogs/WarningsDialog.qml
+++ b/src/xpiks-qt/Dialogs/WarningsDialog.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2

--- a/src/xpiks-qt/Dialogs/ZipArtworksDialog.qml
+++ b/src/xpiks-qt/Dialogs/ZipArtworksDialog.qml
@@ -20,10 +20,10 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Controls 1.2
+import QtQuick.Controls 1.1
 import QtQuick.Layouts 1.1
-import QtQuick.Dialogs 1.2
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Dialogs 1.1
+import QtQuick.Controls.Styles 1.1
 import "../Constants"
 import "../Constants/Colors.js" as Colors;
 import "../Common.js" as Common;

--- a/src/xpiks-qt/Dialogs/ZipArtworksDialog.qml
+++ b/src/xpiks-qt/Dialogs/ZipArtworksDialog.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Layouts 1.1
 import QtQuick.Dialogs 1.2

--- a/src/xpiks-qt/StyledControls/SimpleProgressBar.qml
+++ b/src/xpiks-qt/StyledControls/SimpleProgressBar.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import "../Constants"
 import "../Constants/Colors.js" as Colors
 

--- a/src/xpiks-qt/StyledControls/StyledAddHostButton.qml
+++ b/src/xpiks-qt/StyledControls/StyledAddHostButton.qml
@@ -20,8 +20,8 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Controls 1.2
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Controls 1.1
+import QtQuick.Controls.Styles 1.1
 import "../Constants"
 import "../Constants/Colors.js" as Colors
 

--- a/src/xpiks-qt/StyledControls/StyledAddHostButton.qml
+++ b/src/xpiks-qt/StyledControls/StyledAddHostButton.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
 import "../Constants"

--- a/src/xpiks-qt/StyledControls/StyledBusyIndicator.qml
+++ b/src/xpiks-qt/StyledControls/StyledBusyIndicator.qml
@@ -20,8 +20,8 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Controls 1.3
-import QtQuick.Controls.Styles 1.3
+import QtQuick.Controls 1.1
+import QtQuick.Controls.Styles 1.1
 import "../Constants"
 import "../Constants/Colors.js" as Colors
 

--- a/src/xpiks-qt/StyledControls/StyledBusyIndicator.qml
+++ b/src/xpiks-qt/StyledControls/StyledBusyIndicator.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.2
 import QtQuick.Controls 1.3
 import QtQuick.Controls.Styles 1.3
 import "../Constants"

--- a/src/xpiks-qt/StyledControls/StyledButton.qml
+++ b/src/xpiks-qt/StyledControls/StyledButton.qml
@@ -20,8 +20,8 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Controls 1.2
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Controls 1.1
+import QtQuick.Controls.Styles 1.1
 import "../Constants"
 import "../Constants/Colors.js" as Colors
 

--- a/src/xpiks-qt/StyledControls/StyledButton.qml
+++ b/src/xpiks-qt/StyledControls/StyledButton.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
 import "../Constants"

--- a/src/xpiks-qt/StyledControls/StyledCheckbox.qml
+++ b/src/xpiks-qt/StyledControls/StyledCheckbox.qml
@@ -20,8 +20,8 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Controls 1.2
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Controls 1.1
+import QtQuick.Controls.Styles 1.1
 import "../Constants"
 import "../Constants/Colors.js" as Colors
 

--- a/src/xpiks-qt/StyledControls/StyledCheckbox.qml
+++ b/src/xpiks-qt/StyledControls/StyledCheckbox.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
 import "../Constants"

--- a/src/xpiks-qt/StyledControls/StyledInputHost.qml
+++ b/src/xpiks-qt/StyledControls/StyledInputHost.qml
@@ -20,10 +20,10 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Controls 1.2
+import QtQuick.Controls 1.1
 import QtQuick.Layouts 1.1
-import QtQuick.Dialogs 1.2
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Dialogs 1.1
+import QtQuick.Controls.Styles 1.1
 import "../Constants"
 import "../Constants/Colors.js" as Colors;
 import "../Common.js" as Common;

--- a/src/xpiks-qt/StyledControls/StyledInputHost.qml
+++ b/src/xpiks-qt/StyledControls/StyledInputHost.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Layouts 1.1
 import QtQuick.Dialogs 1.2

--- a/src/xpiks-qt/StyledControls/StyledScrollView.qml
+++ b/src/xpiks-qt/StyledControls/StyledScrollView.qml
@@ -20,10 +20,10 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Controls 1.2
+import QtQuick.Controls 1.1
 import QtQuick.Layouts 1.1
-import QtQuick.Dialogs 1.2
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Dialogs 1.1
+import QtQuick.Controls.Styles 1.1
 import "../Constants"
 import "../Constants/Colors.js" as Colors
 

--- a/src/xpiks-qt/StyledControls/StyledScrollView.qml
+++ b/src/xpiks-qt/StyledControls/StyledScrollView.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Layouts 1.1
 import QtQuick.Dialogs 1.2

--- a/src/xpiks-qt/StyledControls/StyledTabView.qml
+++ b/src/xpiks-qt/StyledControls/StyledTabView.qml
@@ -20,10 +20,10 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Controls 1.2
+import QtQuick.Controls 1.1
 import QtQuick.Layouts 1.1
-import QtQuick.Dialogs 1.2
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Dialogs 1.1
+import QtQuick.Controls.Styles 1.1
 import "../Components"
 import "../Constants"
 import "../Constants/Colors.js" as Colors

--- a/src/xpiks-qt/StyledControls/StyledTabView.qml
+++ b/src/xpiks-qt/StyledControls/StyledTabView.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Layouts 1.1
 import QtQuick.Dialogs 1.2

--- a/src/xpiks-qt/StyledControls/StyledText.qml
+++ b/src/xpiks-qt/StyledControls/StyledText.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import "../Constants"
 import "../Constants/Colors.js" as Colors
 

--- a/src/xpiks-qt/StyledControls/StyledTextEdit.qml
+++ b/src/xpiks-qt/StyledControls/StyledTextEdit.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import "../Constants"
 import "../Constants/Colors.js" as Colors
 

--- a/src/xpiks-qt/StyledControls/StyledTextInput.qml
+++ b/src/xpiks-qt/StyledControls/StyledTextInput.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import "../Constants"
 import "../Constants/Colors.js" as Colors
 

--- a/src/xpiks-qt/main.qml
+++ b/src/xpiks-qt/main.qml
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2

--- a/src/xpiks-qt/main.qml
+++ b/src/xpiks-qt/main.qml
@@ -20,9 +20,9 @@
  */
 
 import QtQuick 2.2
-import QtQuick.Dialogs 1.2
-import QtQuick.Controls 1.2
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Dialogs 1.1
+import QtQuick.Controls 1.1
+import QtQuick.Controls.Styles 1.1
 import QtQuick.Layouts 1.1
 import xpiks 1.0
 import "Constants"


### PR DESCRIPTION
This would allow to run on Ubuntu 14 with packaged QT

Currently two dependencies have to be installed manually:
qtdeclarative5-controls-plugin
qtdeclarative5-quicklayouts-plugin

Updated package is here:
https://mega.nz/#!Ls8CkL7Q!-6P7N9D27TuT4ZuuH0BO3226KFltQka4DqGkMrqRQWo
