### PR TITLE
Debian fixes 1.1.3-2

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,13 +16,13 @@ Exiftool and curl are packed inside the zip archive. Download and extract Xpiks 
 Install the deb file from latest release with all dependencies.
 
 # Special instructions #
+**Linux**
+
+Install all recommended packages:
+- libhunspell
+- hunspell-en-us
 
 **Ubuntu**
-
-Also there is an issue with application menu in Qt for Ubuntu which requires a workaround:
-
-`sudo apt-get remove --purge appmenu-qt5`
-
 **Mint 17.3 (Rose)**
 
 List of QML plugins to be installed manually (from standard repository):
@@ -33,6 +33,11 @@ List of QML plugins to be installed manually (from standard repository):
 - qtdeclarative5-quicklayouts-plugin
 - qtdeclarative5-window-plugin
 - qtdeclarative5-controls-plugin
+
+Also there is an issue with application menu in Qt for Ubuntu which requires a workaround:
+
+`sudo apt-get remove --purge appmenu-qt5`
+
 
 **OpenSuse installation**
 

--- a/src/xpiks-qt/Conectivity/curlftpuploader.cpp
+++ b/src/xpiks-qt/Conectivity/curlftpuploader.cpp
@@ -27,8 +27,9 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cmath>
+#include <curl/curl.h>
 #include "ftphelpers.h"
-#include "../../libcurl/include/curl/curl.h"
+#include "../Common/defines.h"
 
 #define MINIMAL_PROGRESS_FUNCTIONALITY_INTERVAL 2
 

--- a/src/xpiks-qt/Conectivity/ftpcoordinator.cpp
+++ b/src/xpiks-qt/Conectivity/ftpcoordinator.cpp
@@ -32,7 +32,7 @@
 #include "uploadcontext.h"
 #include "ftpuploaderworker.h"
 
-#include "../../libcurl/include/curl/curl.h"
+#include <curl/curl.h>
 
 #define TIMEOUT_SECONDS 10
 #define RETRIES_COUNT 3

--- a/src/xpiks-qt/Conectivity/ftphelpers.cpp
+++ b/src/xpiks-qt/Conectivity/ftphelpers.cpp
@@ -23,7 +23,7 @@
 #include "uploadcontext.h"
 #include <cstdio>
 #include <cstdlib>
-#include "../../libcurl/include/curl/curl.h"
+#include <curl/curl.h>
 
 namespace Conectivity {
     /* The MinGW headers are missing a few Win32 function definitions,

--- a/src/xpiks-qt/Conectivity/ftpuploaderworker.cpp
+++ b/src/xpiks-qt/Conectivity/ftpuploaderworker.cpp
@@ -26,6 +26,7 @@
 #include <QCoreApplication>
 #include "curlftpuploader.h"
 #include "../Models/uploadinfo.h"
+#include "../Common/defines.h"
 
 namespace Conectivity {
     FtpUploaderWorker::FtpUploaderWorker(QSemaphore *uploadSemaphore,

--- a/src/xpiks-qt/Conectivity/testconnection.cpp
+++ b/src/xpiks-qt/Conectivity/testconnection.cpp
@@ -23,7 +23,8 @@
 #include <QDebug>
 #include "uploadcontext.h"
 #include "ftphelpers.h"
-#include "../../libcurl/include/curl/curl.h"
+#include <curl/curl.h>
+#include "Common/defines.h"
 
 namespace Conectivity {
     static size_t throw_away(void *ptr, size_t size, size_t nmemb, void *data) {

--- a/src/xpiks-qt/Dialogs/SettingsWindow.qml
+++ b/src/xpiks-qt/Dialogs/SettingsWindow.qml
@@ -519,7 +519,6 @@ ApplicationWindow {
                                     text: settingsModel.dictionaryPath
                                     anchors.left: parent.left
                                     anchors.leftMargin: 5
-                                    KeyNavigation.backtab: curlText
                                     onTextChanged: settingsModel.dictionaryPath = text
                                 }
                             }

--- a/src/xpiks-qt/Helpers/ziphelper.cpp
+++ b/src/xpiks-qt/Helpers/ziphelper.cpp
@@ -22,7 +22,7 @@
 #include "ziphelper.h"
 #include <QFileInfo>
 #include <QDebug>
-#include <JlCompress.h>
+#include <quazip/JlCompress.h>
 #include "filenameshelpers.h"
 
 namespace Helpers {

--- a/src/xpiks-qt/Models/artworkuploader.cpp
+++ b/src/xpiks-qt/Models/artworkuploader.cpp
@@ -25,6 +25,7 @@
 #include <QDebug>
 #include "uploadinforepository.h"
 #include "uploadinfo.h"
+#include "../Common/defines.h"
 #include "../Helpers/ziphelper.h"
 #include "../Models/artworkmetadata.h"
 #include "../Commands/commandmanager.h"

--- a/src/xpiks-qt/SpellCheck/spellcheckworker.cpp
+++ b/src/xpiks-qt/SpellCheck/spellcheckworker.cpp
@@ -32,7 +32,7 @@
 #include "Helpers/appsettings.h"
 #include "spellcheckitem.h"
 #include "../Common/defines.h"
-#include <hunspell.hxx>
+#include <hunspell/hunspell.hxx>
 
 #define EN_HUNSPELL_DIC "en_US.dic"
 #define EN_HUNSPELL_AFF "en_US.aff"

--- a/src/xpiks-qt/debian/changelog
+++ b/src/xpiks-qt/debian/changelog
@@ -1,4 +1,4 @@
-xpiks (1.1.3-1) UNRELEASED; urgency=medium
+xpiks (1.1.3-2) UNRELEASED; urgency=medium
 
     **Xpiks 1.1 bugfix update 3**. Fixes:
 

--- a/src/xpiks-qt/debian/control
+++ b/src/xpiks-qt/debian/control
@@ -1,12 +1,12 @@
 Source: xpiks
 Standards-Version: 3.9.6
-Build-Depends: debhelper (>= 9), qt5-default (>= 5.2), libhunspell-dev, libquazip-qt5-dev
+Build-Depends: debhelper (>= 9), qt5-default (>= 5.2), libhunspell-dev, libquazip-qt5-dev, libcurl4-gnutls-dev
 Maintainer: Artiom.M <a.mv@gmx.fr>
 
 Package: xpiks
 Architecture: amd64
-Depends: libc6 (>=2.14), libqt5concurrent5 (>= 5.2), libqt5core5a (>= 5.2.0~alpha1), libqt5gui5 (>= 5.2), libqt5network5 (>= 5.2), libqt5qml5 (>= 5.2), libqt5quick5 (>= 5.2), libqt5widgets5 (>= 5.2),  zlib1g (>= 1:1.1.4), curl, exiftool
-Recommends: hunspell-en-us
+Depends: libc6 (>=2.14), libqt5concurrent5 (>= 5.2), libqt5core5a (>= 5.2.0~alpha1), libqt5gui5 (>= 5.2), libqt5network5 (>= 5.2), libqt5qml5 (>= 5.2), libqt5quick5 (>= 5.2), libqt5widgets5 (>= 5.2),  zlib1g (>= 1:1.1.4), libcurl3 (>=7.4), exiftool
+Recommends: libhunspell-1.3-0, hunspell-en-us
 Section: graphics
 Priority: optional
 Homepage: https://github.com/Ribtoks/xpiks

--- a/src/xpiks-qt/main.cpp
+++ b/src/xpiks-qt/main.cpp
@@ -103,7 +103,6 @@ void myMessageHandler(QtMsgType type, const QMessageLogContext &context, const Q
     }
 }
 
-#define TELEMETRY_ENABLED true
 #define STRINGIZE_(x) #x
 #define STRINGIZE(x) STRINGIZE_(x)
 
@@ -201,8 +200,11 @@ int main(int argc, char *argv[]) {
     MetadataIO::BackupSaverService metadataSaverService;
     Helpers::UpdateService updateService;
     MetadataIO::MetadataIOCoordinator metadataIOCoordinator;
-
-    bool telemetryEnabled = appSettings.value(Constants::USER_STATISTIC, TELEMETRY_ENABLED).toBool();
+#ifdef TELEMETRY_ENABLED
+    bool telemetryEnabled = appSettings.value(Constants::USER_STATISTIC,true ).toBool();
+#else
+    bool telemetryEnabled = appSettings.value(Constants::USER_STATISTIC,false).toBool();
+#endif
     Conectivity::TelemetryService telemetryService(userId, telemetryEnabled);
 
     Commands::CommandManager commandManager;

--- a/src/xpiks-qt/xpiks-qt.pro
+++ b/src/xpiks-qt/xpiks-qt.pro
@@ -79,6 +79,7 @@ DEFINES += QT_NO_CAST_TO_ASCII \
            QT_NO_CAST_FROM_BYTEARRAY
 DEFINES += QUAZIP_STATIC
 DEFINES += HUNSPELL_STATIC
+DEFINES += TELEMETRY_ENABLED
 
 # Additional import path used to resolve QML modules in Qt Creator's code model
 QML_IMPORT_PATH =
@@ -230,6 +231,9 @@ DISTFILES += \
 LIBS += -L"$$PWD/../libs/"
 LIBS += -lhunspell
 LIBS += -lz
+LIBS += -lcurl
+LIBS += -lquazip
+
 CONFIG(debug, debug|release)  {
     message("Debug build.")
 } else {
@@ -237,32 +241,36 @@ CONFIG(debug, debug|release)  {
 }
 
 macx {
-    INCLUDEPATH += "../hunspell-1.3.3/src/hunspell"
+    INCLUDEPATH += "../hunspell-1.3.3/src"
     INCLUDEPATH += "../quazip/quazip/"
-    LIBS += -lquazip
-    LIBS += -lcurl
+    INCLUDEPATH += "../../libcurl/include"
 }
 
 win32 {
     INCLUDEPATH += "../zlib-1.2.8"
-    INCLUDEPATH += "../hunspell-1.3.3/src/hunspell"
+    INCLUDEPATH += "../hunspell-1.3.3/src"
     INCLUDEPATH += "../quazip/quazip/"
-    LIBS += -lquazip
+    INCLUDEPATH += "../../libcurl/include"
+    LIBS -= -lcurl
     LIBS += -llibcurl_debug
 }
 
 linux-g++-64 {
     target.path=/usr/bin/
-    INCLUDEPATH += "/usr/include/hunspell"
-    INCLUDEPATH += "/usr/include/quazip"
-    LIBS += -L/lib/x86_64-linux-gnu/
-    LIBS += /usr/lib/x86_64-linux-gnu/libquazip-qt5.a
-
-    # uncomment below for openSUSE build
-    #LIBS += -L/usr/lib64/
-    #LIBS += -lquazip
-    #LIBS += /usr/lib64/libcurl.so.4
     QML_IMPORT_PATH += /usr/lib/x86_64-linux-gnu/qt5/imports/
+    UNAME = $$system(cat /proc/version)
+
+    contains(UNAME, Debian): {
+        message("on Debian Linux")
+        LIBS += -L/lib/x86_64-linux-gnu/
+        LIBS -= -lquazip # temporary static link
+        LIBS += /usr/lib/x86_64-linux-gnu/libquazip-qt5.a
+    }
+    contains(UNAME, SUSE): {
+        message("on SUSE Linux")
+        LIBS += -L/usr/lib64/
+        LIBS += /usr/lib64/libcurl.so.4
+    }
 }
 
 linux-static {


### PR DESCRIPTION
Here is the new package and the changes.
https://mega.nz/#!rl1RhARZ!8KfmUTgfKfenI2t1GVEXfBiRa44BHbP6DfYlZUBrLIk
Future suggestions:
- if you add a new library to include please use _INCLUDEPATH_ variable in .pro file to specify the path to its headers, then in `#include` use just `<name.h>`. This is portable way for headers inclusion.

- disable/enable compile time features from .pro file by adding triggers to _DEFINE_ variable. This avoids useless code modification.