### PR TITLE
Linux compile fixes

### DIFF
--- a/src/xpiks-qt/Conectivity/ftpcoordinator.cpp
+++ b/src/xpiks-qt/Conectivity/ftpcoordinator.cpp
@@ -31,6 +31,7 @@
 #include "curlftpuploader.h"
 #include "uploadcontext.h"
 #include "ftpuploaderworker.h"
+#include "../Common/defines.h"
 
 #include <curl/curl.h>
 

--- a/src/xpiks-qt/MetadataIO/metadataiocoordinator.h
+++ b/src/xpiks-qt/MetadataIO/metadataiocoordinator.h
@@ -26,6 +26,7 @@
 #include <QVector>
 #include <QFutureWatcher>
 #include "../Common/baseentity.h"
+#include "../Common/defines.h"
 
 namespace Models {
     class ArtworkMetadata;

--- a/src/xpiks-qt/Models/artitemsmodel.cpp
+++ b/src/xpiks-qt/Models/artitemsmodel.cpp
@@ -38,6 +38,7 @@
 #include "../SpellCheck/spellcheckiteminfo.h"
 #include "../Common/flags.h"
 #include "../Commands/combinededitcommand.h"
+#include "../Common/defines.h"
 
 namespace Models {
     ArtItemsModel::ArtItemsModel(QObject *parent):

--- a/src/xpiks-qt/Models/filteredartitemsproxymodel.cpp
+++ b/src/xpiks-qt/Models/filteredartitemsproxymodel.cpp
@@ -31,6 +31,7 @@
 #include "../Common/flags.h"
 #include "../SpellCheck/ispellcheckable.h"
 #include "../Helpers/indiceshelper.h"
+#include "../Common/defines.h"
 
 namespace Models {
     FilteredArtItemsProxyModel::FilteredArtItemsProxyModel(QObject *parent) :

--- a/src/xpiks-qt/RPM/xpiks.spec
+++ b/src/xpiks-qt/RPM/xpiks.spec
@@ -1,0 +1,46 @@
+Summary: Xpiks
+Name: xpiks
+Version: 1.2
+Release: 1
+License: GPLv3
+Group: Applications/Internet
+Source: xpiks-qt.tar.gz
+BuildRoot: /var/tmp/%{name}-buildroot
+BuildRequires: libqt5-qtdeclarative-devel libqt5-qtsvg-devel libqt5-qttools-devel libquazip-qt5-devel libqt5-qtquick1-devel quazip-devel hunspell-devel curl-devel
+
+%description
+Cross-platform (X) Photo Keywording Software
+ Xpiks is a free and open source keywording and uploading tool for
+ microstock photographers and illustrators with no hidden fees.
+ If you're tired with copy and pasting keywords from one stock to another,
+ Xpiks would be a great time saver for you!
+
+%prep
+%setup -q -n xpiks-qt
+
+%build
+qmake-qt5 -r -spec linux-g++-64
+
+%install
+rm -rf %{buildroot}
+make install INSTALL_ROOT="%buildroot";
+mkdir -p %{buildroot}%{_datadir}/applications/
+install -D %{_builddir}/xpiks-qt/debian/xpiks.desktop %{buildroot}%{_datadir}/applications/
+mkdir -p %{buildroot}%{_datadir}/icons/
+install -D %{_builddir}/xpiks-qt/debian/xpiks.png %{buildroot}%{_datadir}/icons/
+mkdir -p %{buildroot}%{_datadir}/Xpiks/Xpiks/
+install -D %{_builddir}/xpiks-qt/whatsnew.txt %{buildroot}%{_datadir}/Xpiks/Xpiks/
+install -D %{_builddir}/xpiks-qt/terms_and_conditions.txt %{buildroot}%{_datadir}/Xpiks/Xpiks/
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root)
+%{_bindir}/*
+%{_datadir}/*
+
+
+%changelog
+* Wed Mar 2 2016 Artiom Molchanov <a.mv@gmx.fr> 
+- RPM build on OpenSuse

--- a/src/xpiks-qt/debian/changelog
+++ b/src/xpiks-qt/debian/changelog
@@ -1,3 +1,18 @@
+xpiks (1.2-1) UNRELEASED; urgency=medium
+
+    **Major features of this release:**
+
+    - switching between list and grid view options
+    - ability to explicitly attach vectors to previews
+    - automatic exiftool detection for OS X users
+    - upload progress reporting in taskbar on Windows
+    - ability to correctly upload vectors to Dreamtimes (to the 'additional' directory)
+    - larger description field in all popups
+    - logs are now highlighted
+
+ -- Artiom.M <a.mv@gmx.fr>  Wed, 2 Mar 2016 08:00:00 +0200
+
+
 xpiks (1.1.4-1) UNRELEASED; urgency=medium
 
     **Xpiks 1.1 bugfix update 4**. Fixes:

--- a/src/xpiks-qt/debian/control
+++ b/src/xpiks-qt/debian/control
@@ -1,11 +1,11 @@
 Source: xpiks
 Standards-Version: 3.9.6
-Build-Depends: debhelper (>= 9), qt5-default (>= 5.2), libhunspell-dev, libquazip-qt5-dev, libcurl4-gnutls-dev
+Build-Depends: debhelper (>= 9), qt5-default (>= 5.2), libqt5svg5-dev, libhunspell-dev, libquazip-qt5-dev, libcurl4-gnutls-dev
 Maintainer: Artiom.M <a.mv@gmx.fr>
 
 Package: xpiks
 Architecture: amd64
-Depends: libc6 (>=2.14), libqt5concurrent5 (>= 5.2), libqt5core5a (>= 5.2.0~alpha1), libqt5gui5 (>= 5.2), libqt5network5 (>= 5.2), libqt5qml5 (>= 5.2), libqt5quick5 (>= 5.2), libqt5widgets5 (>= 5.2),  zlib1g (>= 1:1.1.4), libcurl3 (>=7.4), exiftool
+Depends: libc6 (>=2.14), libqt5concurrent5 (>= 5.2), libqt5core5a (>= 5.2.0~alpha1), libqt5gui5 (>= 5.2), libqt5network5 (>= 5.2), libqt5qml5 (>= 5.2), libqt5quick5 (>= 5.2), libqt5widgets5 (>= 5.2),libqt5svg5 (>= 5.2),  zlib1g (>= 1:1.1.4), libcurl3 (>=7.4), exiftool
 Recommends: libhunspell-1.3-0, hunspell-en-us
 Section: graphics
 Priority: optional

--- a/src/xpiks-qt/xpiks-qt.pro
+++ b/src/xpiks-qt/xpiks-qt.pro
@@ -291,15 +291,15 @@ win32 {
     INCLUDEPATH += "../libcurl/include"
     LIBS -= -lcurl
 
-CONFIG(debug, debug|release) {
-    EXE_DIR = debug
-    LIBS += -llibcurl_debug
-}
+    CONFIG(debug, debug|release) {
+	EXE_DIR = debug
+        LIBS += -llibcurl_debug
+    }
 
-CONFIG(release, debug|release) {
-    EXE_DIR = release
-    LIBS += -llibcurl
-}
+    CONFIG(release, debug|release) {
+        EXE_DIR = release
+        LIBS += -llibcurl
+    }
 
     copywhatsnew.commands = $(COPY_FILE) \"$$shell_path($$PWD/whatsnew.txt)\" \"$$shell_path($$OUT_PWD/$$EXE_DIR/)\"
     copyterms.commands = $(COPY_FILE) \"$$shell_path($$PWD/terms_and_conditions.txt)\" \"$$shell_path($$OUT_PWD/$$EXE_DIR/)\"
@@ -310,28 +310,33 @@ CONFIG(release, debug|release) {
 }
 
 linux-g++-64 {
+    message("for Linux")
     target.path=/usr/bin/
     QML_IMPORT_PATH += /usr/lib/x86_64-linux-gnu/qt5/imports/
-    UNAME = $$system(cat /proc/version)
     #DEFINES -= TELEMETRY_ENABLED
+    LIBS += -L/lib/x86_64-linux-gnu/
 
-    contains(UNAME, Debian): {
-        message("on Debian Linux")
-        LIBS += -L/lib/x86_64-linux-gnu/
+    UNAME = $$system(cat /proc/version | tr -d \'()\')
+    contains( UNAME, Debian ) {
+        message("distribution : Debian")
         LIBS -= -lquazip # temporary static link
         LIBS += /usr/lib/x86_64-linux-gnu/libquazip-qt5.a
     }
-    contains(UNAME, SUSE): {
-        message("on SUSE Linux")
+    contains( UNAME, SUSE ) {
+        message("distribution : SUSE")
+    }
+
+
+}
+
+linux-qtcreator {
+        message("in QtCreator")
         LIBS += -L/usr/lib64/
         LIBS += /usr/lib64/libcurl.so.4
         copywhatsnew.commands = $(COPY_FILE) "$$PWD/whatsnew.txt" "$$OUT_PWD/"
         copyterms.commands = $(COPY_FILE) "$$PWD/terms_and_conditions.txt" "$$OUT_PWD/"
         QMAKE_EXTRA_TARGETS += copywhatsnew copyterms
 	POST_TARGETDEPS += copywhatsnew copyterms
-    }
-
-
 }
 
 linux-static {


### PR DESCRIPTION
Here are few fixes for the new version and this time ....  RPM package is ready !!!
https://mega.nz/#!f50gSTDC!QYLUBIlNh-w7fKobN5Hih0_R2s_6NgZnc-FOjsGYYCM
Please test it. It was successfully installed and worked on my OpenSuse build virtual machine.
There are some changes in .pro file. I put aside your options for QTcreator compile (I suppose). In order to use them just add CONFIG+=linux-qtcreator to you qmake command line in project build config.
DEB: https://mega.nz/#!ak1BQAIS!TDGzkjMp5lNNiA6KpSTA5FD-cqepX8Lt7aeP75bD7j8
