### PR TITLE
Linux package

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,6 +33,7 @@ List of QML plugins to be installed manually (from standard repository):
 - qtdeclarative5-quicklayouts-plugin
 - qtdeclarative5-window-plugin
 - qtdeclarative5-controls-plugin
+- qml-module-qtgraphicaleffects
 
 Also there is an issue with application menu in Qt for Ubuntu which requires a workaround:
 

--- a/src/xpiks-qt/Common/defines.h
+++ b/src/xpiks-qt/Common/defines.h
@@ -26,6 +26,7 @@
 #include <QThread>
 #include <QDebug>
 #include <QDateTime>
+#include <QStandardPaths>
 
 #ifdef QT_NO_DEBUG
 #define WITH_LOGS
@@ -46,8 +47,10 @@
 #define LOG_WARNING qWarning()
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
+#define XPIKS_DATA_LOCATION_TYPE QStandardPaths::AppDataLocation
 #define XPIKS_USERDATA_PATH QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
 #else
+#define XPIKS_DATA_LOCATION_TYPE QStandardPaths::DataLocation
 #define XPIKS_USERDATA_PATH QStandardPaths::writableLocation(QStandardPaths::DataLocation);
 #endif
 

--- a/src/xpiks-qt/Helpers/appsettings.h
+++ b/src/xpiks-qt/Helpers/appsettings.h
@@ -38,19 +38,12 @@ namespace Helpers {
         Q_OBJECT
 
     public:
-        QStandardPaths::StandardLocation appDataLocationType;
-
         explicit AppSettings(QObject *parent = 0) : QSettings(QSettings::UserScope,
                                                               QCoreApplication::instance()->organizationName(),
                                                               QCoreApplication::instance()->applicationName(),
                                                               parent)
         {
-            #if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
-                appDataLocationType = QStandardPaths::AppDataLocation;
-            #else
-                appDataLocationType = QStandardPaths::DataLocation;
-            #endif
-            //LOG_DEBUG<< "Extra files search locations: "<<QStandardPaths::standardLocations(appDataLocationType);
+            LOG_DEBUG<< "Extra files search locations: "<<QStandardPaths::standardLocations(XPIKS_DATA_LOCATION_TYPE);
         }
 
         QString getAppWidthKey()   const { return QLatin1String(Constants::APP_WINDOW_WIDTH); }
@@ -160,7 +153,7 @@ namespace Helpers {
             path += QDir::separator() + QLatin1String(Constants::WHATS_NEW_FILENAME);
             path = QDir::cleanPath(path);
 #else
-            path = QStandardPaths::locate(appDataLocationType, Constants::WHATS_NEW_FILENAME);
+            path = QStandardPaths::locate(XPIKS_DATA_LOCATION_TYPE, Constants::WHATS_NEW_FILENAME);
 #endif
             QFile file(path);
             if (file.open(QIODevice::ReadOnly)) {
@@ -291,7 +284,7 @@ namespace Helpers {
             path += QDir::separator() + QLatin1String(Constants::TERMS_AND_CONDITIONS_FILENAME);
             path = QDir::cleanPath(path);
 #else
-            path = QStandardPaths::locate(appDataLocationType, Constants::TERMS_AND_CONDITIONS_FILENAME);
+            path = QStandardPaths::locate(XPIKS_DATA_LOCATION_TYPE, Constants::TERMS_AND_CONDITIONS_FILENAME);
 #endif
             QFile file(path);
             if (file.open(QIODevice::ReadOnly)) {

--- a/src/xpiks-qt/Models/languagesmodel.cpp
+++ b/src/xpiks-qt/Models/languagesmodel.cpp
@@ -38,15 +38,17 @@ namespace Models {
         m_QtTranslator = new QTranslator(this);
 
         QString translationsPath;
-#if !defined(Q_OS_LINUX)
+
+#if defined(Q_OS_LINUX)
+        translationsPath = QStandardPaths::locate(XPIKS_DATA_LOCATION_TYPE, "/translations/",QStandardPaths::LocateDirectory);
+#else
         translationsPath = QCoreApplication::applicationDirPath();
 #if defined(Q_OS_MAC)
         translationsPath += "/../Resources/translations/";
-#elif defined(Q_OS_WIN)
+#else
         translationsPath += "/translations/";
 #endif
 #endif
-
         m_TranslationsPath = translationsPath;
     }
 

--- a/src/xpiks-qt/Suggestion/suggestionqueryenginebase.h
+++ b/src/xpiks-qt/Suggestion/suggestionqueryenginebase.h
@@ -43,7 +43,7 @@ namespace Suggestion {
 
         void setResults(const QVector<SuggestionArtwork *> &results) {
             m_LastResults.clear();
-            m_LastResults.append(results);
+            m_LastResults+=results;
         }
 
     signals:

--- a/src/xpiks-qt/debian/changelog
+++ b/src/xpiks-qt/debian/changelog
@@ -1,3 +1,11 @@
+xpiks (1.3) UNRELEASED; urgency=medium
+
+    **Major features of this release:**
+
+
+ -- Artiom.M <a.mv@gmx.fr>  Tue, 26 Apr 2016 08:00:00 +0200
+
+
 xpiks (1.2-1) UNRELEASED; urgency=medium
 
     **Major features of this release:**

--- a/src/xpiks-qt/debian/control
+++ b/src/xpiks-qt/debian/control
@@ -1,6 +1,6 @@
 Source: xpiks
 Standards-Version: 3.9.6
-Build-Depends: debhelper (>= 9), qt5-default (>= 5.2), libqt5svg5-dev, libhunspell-dev, libquazip-qt5-dev, libcurl4-gnutls-dev
+Build-Depends: debhelper (>= 9), qt5-default (>= 5.2), libqt5svg5-dev,qttools5-dev-tools, libhunspell-dev, libquazip-qt5-dev, libcurl4-gnutls-dev
 Maintainer: Artiom.M <a.mv@gmx.fr>
 
 Package: xpiks

--- a/src/xpiks-qt/debian/install
+++ b/src/xpiks-qt/debian/install
@@ -1,4 +1,5 @@
 debian/xpiks.desktop usr/share/applications
 debian/xpiks.png usr/share/icons
-whatsnew.txt usr/share/Xpiks/Xpiks
-terms_and_conditions.txt usr/share/Xpiks/Xpiks
+deps/whatsnew.txt usr/share/Xpiks/Xpiks
+deps/terms_and_conditions.txt usr/share/Xpiks/Xpiks
+deps/translations/*.qm usr/share/Xpiks/Xpiks/translations

--- a/src/xpiks-qt/xpiks-qt.pro
+++ b/src/xpiks-qt/xpiks-qt.pro
@@ -402,6 +402,7 @@ linux-g++-64 {
     QML_IMPORT_PATH += /usr/lib/x86_64-linux-gnu/qt5/imports/
     LIBS += -L/lib/x86_64-linux-gnu/
     BUILDNO = $$system(od -An -N8 -tx8 </dev/urandom)
+    DEFINES -= TELEMETRY_ENABLED
 
     UNAME = $$system(cat /proc/version | tr -d \'()\')
     contains( UNAME, Debian ) {

--- a/src/xpiks-qt/xpiks-qt.pro
+++ b/src/xpiks-qt/xpiks-qt.pro
@@ -402,7 +402,7 @@ linux-g++-64 {
     QML_IMPORT_PATH += /usr/lib/x86_64-linux-gnu/qt5/imports/
     LIBS += -L/lib/x86_64-linux-gnu/
     BUILDNO = $$system(od -An -N8 -tx8 </dev/urandom)
-    DEFINES -= TELEMETRY_ENABLED
+    #DEFINES -= TELEMETRY_ENABLED
 
     UNAME = $$system(cat /proc/version | tr -d \'()\')
     contains( UNAME, Debian ) {
@@ -418,7 +418,7 @@ linux-g++-64 {
 linux-qtcreator {
         message("in QtCreator")
         LIBS += -L/usr/lib64/
-        LIBS += /usr/lib64/libcurl.so.4
+        LIBS += -L/lib/x86_64-linux-gnu/
         BUILDNO = $$system(od -An -N8 -tx8 </dev/urandom)
         
         copywhatsnew.commands = $(COPY_FILE) "$$PWD/deps/whatsnew.txt" "$$OUT_PWD/"


### PR DESCRIPTION
Few words about fixes:

- qml-module-qtgraphicaleffects is currently in manual install section. I need to check in SUSE and UBUNTU if the name is the same.
- QStandardPaths::locate is the most appropriate way of looking for a file in XDG directories for Linux. I think in QT you can use it for any OS as well with defaults fitting well with your current implementation. In this way you would be able to avoid all these #ifdef #endif staff. If not, it would be better to move #ifdef logic to defines.h. 